### PR TITLE
Make the maximum number of reported fusions configurable via --max-num-f...

### DIFF
--- a/doc/html/fusion_manual.html
+++ b/doc/html/fusion_manual.html
@@ -86,6 +86,12 @@
 	      The default is 0.
 	  </td></tr>
 	  <tr><td VALIGN=top nowrap>
+	  <tt>--max-num-fusions</tt>
+	  </td><td VALIGN=top>
+	      The maximum number of reported fusions.
+	      The default is 500.
+	  </td></tr>
+	  <tr><td VALIGN=top nowrap>
 	      <tt>--fusion-read-mismatches</tt>
 	    </td><td VALIGN=top>
 	      Reads support fusions if they map across fusion with at most this many mismatches.

--- a/src/tophat-fusion-post
+++ b/src/tophat-fusion-post
@@ -68,6 +68,7 @@ class TopHatFusionParams:
         self.num_fusion_reads = 3
         self.num_fusion_pairs = 2
         self.num_fusion_both = 0
+        self.max_num_fusions = 500
 
         self.fusion_read_mismatches = 2
         self.fusion_multireads = 2
@@ -101,6 +102,7 @@ class TopHatFusionParams:
                                          "num-fusion-reads=",
                                          "num-fusion-pairs=",
                                          "num-fusion-both=",
+                                         "max-num-fusions=",
                                          "fusion-read-mismatches=",
                                          "fusion-multireads=",
                                          "non-human",
@@ -129,6 +131,8 @@ class TopHatFusionParams:
                 self.num_fusion_pairs = int(value)
             if option == "--num-fusion-both":
                 self.num_fusion_both = int(value)
+            if option == "--max-num-fusions":
+                self.max_num_fusions = int(value)
             if option == "--fusion-read-mismatches":
                 self.fusion_read_mismatches = int(value)
             if option == "--fusion-multireads":
@@ -2177,8 +2181,7 @@ def generate_html(params):
 
         cluster_temp_list = sorted(cluster_temp_list2, cmp=cmp)
 
-        max_num_fusions = 500
-        for i in range(min(max_num_fusions, len(cluster_temp_list))):
+        for i in range(min(params.max_num_fusions, len(cluster_temp_list))):
             do_not_add = False
             indices = cluster_temp_list[i]["index"]
             if not do_not_add:


### PR DESCRIPTION
...usions=N.

An alternative name would be --num-fusion-max to stay in line with the other --num-fusion-* options.