### PR TITLE
rectified samtools issue

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -108,10 +108,10 @@ CXXFLAGS="$CFLAGS"
 CXXFLAGS="$CXXFLAGS $BAM_CPPFLAGS $BOOST_CPPFLAGS -I./SeqAn-1.3"
 LDFLAGS="$BAM_LDFLAGS $BOOST_LDFLAGS $user_LDFLAGS"
 
-AM_INIT_AUTOMAKE([-Wall foreign tar-pax foreign])
+AM_INIT_AUTOMAKE([-Wall foreign tar-pax foreign subdir-objects])
 
 # makefiles to configure
-AC_CONFIG_FILES([Makefile src/Makefile])
+AC_CONFIG_FILES([Makefile src/Makefile src/samtools-0.1.18/Makefile src/samtools-0.1.18/bcftools/Makefile])
 
 # make it happen
 AC_OUTPUT

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -606,11 +606,12 @@ SAMPROG = samtools_0.1.18
 BAM_LIB = -lbam
 BAM_CPPFLAGS = -I$(SAMDIR)
 BAM_LDFLAGS = -L$(SAMDIR)
+AM_CFLAGS = $(BAM_CPPFLAGS)
+
 
 #-- progs to be installed in $prefix/bin
-
+#	$(SAMPROG) \  <-- removed because samtools has a Makefile.am that works off the same autotools config as this, and is set to compile first
 bin_PROGRAMS = \
-	$(SAMPROG) \
 	prep_reads \
 	gtf_to_fasta \
 	fix_map_ordering \
@@ -643,9 +644,9 @@ dist_bin_SCRIPTS = \
 CLEANFILES = \
 	tophat2 \
 	tophat
-
-clean-local:
-	cd $(SAMDIR) && make clean
+## this should be unnecessary now, it should auto-generate cleaning data 
+#clean-local:
+#	cd $(SAMDIR) && make clean
 
 tophat2: tophat2.in
 	sed -e 's|__PREFIX__|$(prefix)|' tophat2.in > tophat2
@@ -654,7 +655,7 @@ tophat: tophat.py
 	sed -e 's|__VERSION__|$(VERSION)|' tophat.py > tophat
 
 #-- tophat library for linking convienence
-noinst_LIBRARIES = $(SAMLIB) libgc.a libtophat.a
+noinst_LIBRARIES = libgc.a libtophat.a #$(SAMLIB) <-- will be handled properly in subdir
 
 noinst_HEADERS = \
 	reads.h \
@@ -767,11 +768,13 @@ gtf_to_fasta_LDADD = $(top_builddir)/src/libtophat.a libgc.a $(BAM_LIB)
 gtf_to_fasta_LDFLAGS = $(BAM_LDFLAGS) $(LDFLAGS)
 
 
-libbam_a_SOURCES = 
-samtools_0_1_18_SOURCES = 
+#libbam_a_SOURCES = 
+#samtools_0_1_18_SOURCES = 
 
-$(SAMPROG): $(SAMLIB)
+#$(SAMPROG): $(SAMLIB)
 	
 
-$(SAMLIB):
-	cd $(SAMDIR) && make $(SAMPROG) && cp $(SAMLIB) $(SAMPROG) ..
+#$(SAMLIB):
+#	cd $(SAMDIR) && bash -c "make" #$(SAMPROG) && cp $(SAMLIB) $(SAMPROG) ..
+
+SUBDIRS = samtools-0.1.18 .

--- a/src/samtools-0.1.18/Makefile.am
+++ b/src/samtools-0.1.18/Makefile.am
@@ -1,0 +1,40 @@
+
+AM_CFLAGS = -g -Wall -O2 #-m64 #-arch ppc
+DFLAGS = -D_FILE_OFFSET_BITS=64 -D_LARGEFILE64_SOURCE -D_USE_KNETFILE -D_CURSES_LIB=0
+ARFLAGS = -csru
+
+#ldflags for samtools -lbcf -lm -lz -lcurses
+#ldflags for razip & bgzip : -lz
+#faidx_main.o:faidx.h razf.h <--- might need this
+
+#libbam uses Lobjs
+#samtools uses aobjs and links against libbam
+#razip and bgzip use knetfile
+
+#actual libraries
+noinst_LIBRARIES = libbam.a
+
+libbam_a_SOURCES = 	bgzf.h bgzf.c kstring.h kstring.c bam_aux.h bam_aux.c bam.c bam.h razf.h bam_endian.h \
+			sam_header.h bam_import.c kseq.h khash.h sam.c sam.h bam_index.c ksort.h bam_pileup.c \
+			bam_lpileup.c bam_md.c faidx.h razf.c faidx.c bedidx.h bedidx.c knetfile.h knetfile.c \
+			bam_sort.h bam_sort.c sam_header.c bam_reheader.h bam_reheader.c kprobaln.h kprobaln.c \
+			bam_cat.h bam_cat.c
+
+bin_PROGRAMS = samtools_0.1.18
+EXTRA_PROGRAMS = razip bgzip
+
+samtools_0_1_18_SOURCES = bam_tview.h bam_tview.c bam_plcmd.c bam.h faidx.h bcftools/bcf.h bam2bcf.h sam_view.h \
+			sam_view.c bam_rmdup.h bam_rmdup.c bam_rmdupse.h bam_rmdupse.c bam_mate.h bam_mate.c \
+			bam_stat.h bam_stat.c bam_color.h bam_color.c bamtk.c kaln.h kaln.c bam2bcf.c errmod.h \
+			bam2bcf_indel.c errmod.c sample.h sample.c cut_target.h cut_target.c phase.c khash.h \
+			ksort.h bam2depth.h bam2depth.c
+
+samtools_0_1_18_LDADD = libbam.a bcftools/libbcf.a -lm -lz -lcurses
+
+razip_SOURCES =  razip.c razf.c razf.h knetfile.h knetfile.c
+razip_LDADD = -lz
+bgzip_SOURCES =  bgzip.c bgzf.h bgzf.c knetfile.h knetfile.c
+bgzip_LDADD = -lz
+
+
+SUBDIRS= bcftools .

--- a/src/samtools-0.1.18/Makefile.original.old
+++ b/src/samtools-0.1.18/Makefile.original.old
@@ -1,0 +1,93 @@
+CC=			gcc
+CFLAGS=		-g -Wall -O2 #-m64 #-arch ppc
+DFLAGS=		-D_FILE_OFFSET_BITS=64 -D_LARGEFILE64_SOURCE -D_USE_KNETFILE -D_CURSES_LIB=0
+KNETFILE_O=	knetfile.o
+LOBJS=		bgzf.o kstring.o bam_aux.o bam.o bam_import.o sam.o bam_index.o	\
+			bam_pileup.o bam_lpileup.o bam_md.o razf.o faidx.o bedidx.o \
+			$(KNETFILE_O) bam_sort.o sam_header.o bam_reheader.o kprobaln.o bam_cat.o
+AOBJS=		bam_tview.o bam_plcmd.o sam_view.o	\
+			bam_rmdup.o bam_rmdupse.o bam_mate.o bam_stat.o bam_color.o	\
+			bamtk.o kaln.o bam2bcf.o bam2bcf_indel.o errmod.o sample.o \
+			cut_target.o phase.o bam2depth.o
+PROG=		samtools_0.1.18
+INCLUDES=	-I.
+SUBDIRS=	. bcftools
+LIBPATH=
+LIBCURSES=	-lcurses
+
+.SUFFIXES:.c .o
+
+.c.o:
+		$(CC) -c $(CFLAGS) $(DFLAGS) $(INCLUDES) $< -o $@
+
+all-recur lib-recur clean-recur cleanlocal-recur install-recur:
+		@target=`echo $@ | sed s/-recur//`; \
+		wdir=`pwd`; \
+		list='$(SUBDIRS)'; for subdir in $$list; do \
+			cd $$subdir; \
+			$(MAKE) CC="$(CC)" DFLAGS="$(DFLAGS)" CFLAGS="$(CFLAGS)" \
+				INCLUDES="$(INCLUDES)" LIBPATH="$(LIBPATH)" $$target || exit 1; \
+			cd $$wdir; \
+		done;
+
+all:$(PROG)
+
+.PHONY:all lib clean cleanlocal
+.PHONY:all-recur lib-recur clean-recur cleanlocal-recur install-recur
+
+lib:libbam.a
+
+libbam.a:$(LOBJS)
+		$(AR) -csru $@ $(LOBJS)
+
+samtools_0.1.18:lib-recur $(AOBJS)
+		$(CC) $(CFLAGS) -o $@ $(AOBJS) -Lbcftools $(LIBPATH) libbam.a -lbcf -lm -lz #$(LIBCURSES)
+
+razip:razip.o razf.o $(KNETFILE_O)
+		$(CC) $(CFLAGS) -o $@ razf.o razip.o $(KNETFILE_O) -lz
+
+bgzip:bgzip.o bgzf.o $(KNETFILE_O)
+		$(CC) $(CFLAGS) -o $@ bgzf.o bgzip.o $(KNETFILE_O) -lz
+
+razip.o:razf.h
+bam.o:bam.h razf.h bam_endian.h kstring.h sam_header.h
+sam.o:sam.h bam.h
+bam_import.o:bam.h kseq.h khash.h razf.h
+bam_pileup.o:bam.h razf.h ksort.h
+bam_plcmd.o:bam.h faidx.h bcftools/bcf.h bam2bcf.h
+bam_index.o:bam.h khash.h ksort.h razf.h bam_endian.h
+bam_lpileup.o:bam.h ksort.h
+bam_tview.o:bam.h faidx.h
+bam_sort.o:bam.h ksort.h razf.h
+bam_md.o:bam.h faidx.h
+sam_header.o:sam_header.h khash.h
+bcf.o:bcftools/bcf.h
+bam2bcf.o:bam2bcf.h errmod.h bcftools/bcf.h
+bam2bcf_indel.o:bam2bcf.h
+errmod.o:errmod.h
+phase.o:bam.h khash.h ksort.h
+bamtk.o:bam.h
+
+faidx.o:faidx.h razf.h khash.h
+faidx_main.o:faidx.h razf.h
+
+
+libbam.1.dylib-local:$(LOBJS)
+		libtool -dynamic $(LOBJS) -o libbam.1.dylib -lc -lz
+
+libbam.so.1-local:$(LOBJS)
+		$(CC) -shared -Wl,-soname,libbam.so -o libbam.so.1 $(LOBJS) -lc -lz
+
+dylib:
+		@$(MAKE) cleanlocal; \
+		case `uname` in \
+			Linux) $(MAKE) CFLAGS="$(CFLAGS) -fPIC" libbam.so.1-local;; \
+			Darwin) $(MAKE) CFLAGS="$(CFLAGS) -fPIC" libbam.1.dylib-local;; \
+			*) echo 'Unknown OS';; \
+		esac
+
+
+cleanlocal:
+		rm -fr gmon.out *.o a.out *.exe *.dSYM razip bgzip $(PROG) *~ *.a *.so.* *.so *.dylib
+
+clean:cleanlocal-recur

--- a/src/samtools-0.1.18/bcftools/Makefile.am
+++ b/src/samtools-0.1.18/bcftools/Makefile.am
@@ -1,0 +1,14 @@
+AM_CFLAGS = -I$(top_srcdir)/src/samtools-0.1.18
+
+lib_LIBRARIES = libbcf.a
+#bcf.o vcf.o bcfutils.o prob1.o em.o kfunc.o kmin.o index.o fet.o mut.o bcf2qcall.o
+libbcf_a_SOURCES = bcf.h kmin.h prob1.h \
+		bcf.c kmin.c prob1.c \
+		vcf.c bcfutils.c em.c kfunc.c index.c fet.c mut.c bcf2qcall.c
+
+bin_PROGRAMS = bcftools
+#call1.o main.o $(OMISC)/kstring.o $(OMISC)/bgzf.o $(OMISC)/knetfile.o $(OMISC)/bedidx.o
+bcftools_SOURCES = main.c call1.c \
+		../kstring.h ../bgzf.h ../knetfile.h \
+		../kstring.c ../bgzf.c ../knetfile.c ../bedidx.c
+bcftools_LDADD = libbcf.a -lm -lz

--- a/src/samtools-0.1.18/bcftools/Makefile.original.old
+++ b/src/samtools-0.1.18/bcftools/Makefile.original.old
@@ -1,0 +1,51 @@
+CC=			gcc
+CFLAGS=		-g -Wall -O2 #-m64 #-arch ppc
+DFLAGS=		-D_FILE_OFFSET_BITS=64 -D_USE_KNETFILE
+LOBJS=		bcf.o vcf.o bcfutils.o prob1.o em.o kfunc.o kmin.o index.o fet.o mut.o bcf2qcall.o
+OMISC=		..
+AOBJS=		call1.o main.o $(OMISC)/kstring.o $(OMISC)/bgzf.o $(OMISC)/knetfile.o $(OMISC)/bedidx.o
+PROG=		bcftools
+INCLUDES=	
+SUBDIRS=	.
+
+.SUFFIXES:.c .o
+
+.c.o:
+		$(CC) -c $(CFLAGS) $(DFLAGS) -I.. $(INCLUDES) $< -o $@
+
+all-recur lib-recur clean-recur cleanlocal-recur install-recur:
+		@target=`echo $@ | sed s/-recur//`; \
+		wdir=`pwd`; \
+		list='$(SUBDIRS)'; for subdir in $$list; do \
+			cd $$subdir; \
+			$(MAKE) CC="$(CC)" DFLAGS="$(DFLAGS)" CFLAGS="$(CFLAGS)" \
+				INCLUDES="$(INCLUDES)" LIBPATH="$(LIBPATH)" $$target || exit 1; \
+			cd $$wdir; \
+		done;
+
+all:$(PROG)
+
+lib:libbcf.a
+
+libbcf.a:$(LOBJS)
+		$(AR) -csru $@ $(LOBJS)
+
+bcftools:lib $(AOBJS)
+		$(CC) $(CFLAGS) -o $@ $(AOBJS) -L. $(LIBPATH) -lbcf -lm -lz
+
+bcf.o:bcf.h
+vcf.o:bcf.h
+index.o:bcf.h
+bcfutils.o:bcf.h
+prob1.o:prob1.h bcf.h
+call1.o:prob1.h bcf.h
+bcf2qcall.o:bcf.h
+main.o:bcf.h
+
+bcf.pdf:bcf.tex
+		pdflatex bcf
+
+cleanlocal:
+		rm -fr gmon.out *.o a.out *.dSYM $(PROG) *~ *.a bcf.aux bcf.log bcf.pdf *.class libbcf.*.dylib libbcf.so*
+
+clean:cleanlocal-recur

--- a/unbootstrap
+++ b/unbootstrap
@@ -2,6 +2,8 @@
 # Reverses the actions of bootstrap
 #
 
+echo "unboostrapping tophat"
+
 echo "- removing m4 macros"
 rm -f aclocal.m4
 rm -rf autom4te.cache
@@ -14,6 +16,9 @@ rm -f `find . -name Makefile.in`
 
 echo "- removing conifgure script"
 rm -f configure
+
+echo "- removing other files added by autotools"
+rm -f ./ar-lib ./compile ./config.guess ./config.sub ./depcomp ./install-sh ./missing 
 
 echo "UNBOOTSTRAP COMPLETE"
 


### PR DESCRIPTION
might require some minor touching up to make sure I didn't bungle any of the flags, miss any source file listings or make things propogate from the configure scripts for tophat instead of being hardcoded (like -lz -lm etc.). I would think if I HAD messed up by missing a header or a *.c file it would probably complain.

Probably need to add those headers to a nodist variable.

I have the same compiling error that the official repository does when doing an out of source build now, and it gets through building the samtools binary and libbam.a just fine.