### PR TITLE
Build fixes for FreeBSD + clang.

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -9,6 +9,7 @@
  *
  */
 #include <stdint.h>
+#include <unistd.h>
 #include <cassert>
 #include <cstring>
 #include <cstdlib>

--- a/src/samtools-0.1.18/Makefile
+++ b/src/samtools-0.1.18/Makefile
@@ -1,5 +1,5 @@
-CC=			gcc
-CFLAGS=		-g -Wall -O2 #-m64 #-arch ppc
+CC?=			gcc
+CFLAGS?=		-g -Wall -O2 #-m64 #-arch ppc
 DFLAGS=		-D_FILE_OFFSET_BITS=64 -D_LARGEFILE64_SOURCE -D_USE_KNETFILE -D_CURSES_LIB=0
 KNETFILE_O=	knetfile.o
 LOBJS=		bgzf.o kstring.o bam_aux.o bam.o bam_import.o sam.o bam_index.o	\


### PR DESCRIPTION
- don't hardcode CC and CFLAGS in samtools
- add a missing include