### PR TITLE
tophat2 uses relative path logic to find tophat executable...

### DIFF
--- a/src/tophat2.in
+++ b/src/tophat2.in
@@ -1,15 +1,4 @@
 #!/bin/bash
-prefix="__PREFIX__"
-pbin=""
-if [[ -z $prefix ]]; then
-   fl=$(readlink $0)
-   if [[ -z $fl ]]; then
-     pbin=$(dirname $0)
-   else
-     pbin=$(dirname $fl)
-   fi
-else
- pbin=$prefix/bin
-fi
+pbin="$( readlink -f "$( dirname "${BASH_SOURCE[0]}" )" )";
 export PATH=$pbin:$PATH
 $pbin/tophat "$@"


### PR DESCRIPTION
...rather than the absolute prefix from compile time.