### PR TITLE
equal_bam now checks if both alignments are to the same strand

### DIFF
--- a/src/bam_merge.h
+++ b/src/bam_merge.h
@@ -43,6 +43,9 @@ struct equal_bam {
 
     if (first.b->core.n_cigar != second.b->core.n_cigar)
       return false;
+    
+    if ((first.b->core.flag & BAM_FREVERSE) != (second.b->core.flag & BAM_FREVERSE))
+      return false;
 
     for (int i = 0; i < first.b->core.n_cigar; ++i){
       if (bam1_cigar(first.b)[i] != bam1_cigar(second.b)[i])


### PR DESCRIPTION
I have recently been testing tophat2 by creating a artificial set of short reads from a transcriptome and mapping these reads with --report-secondary-alignemnts, --no-novel-juncs, and --read-realign-edit-dist 0.
I have been trying to track down all cases in which a read is reported as mapping uniquely (i.e. with MAPQ 50) to a different location than its known "true" location.  

One cause of such cases is short palindromic reads that are reported as mapping uniquely to one strand even though they align equally well to either strand. An IGV screenshot of an example from e. coli is shown below. A read of length 16 was generated from the transcript on the reverse strand (as indicated by the left-facing arrows in the transcript annotation). This sequence happens to be a perfect (reverse-complement) palindrome, and tophat incorrectly reports a MAPQ=50 alignment to the forward strand.
![palindrome](https://cloud.githubusercontent.com/assets/1636913/11637189/dc3ce940-9cd4-11e5-858f-47d9c869a83b.png)

I have tracked this down to BamMerge::next_bam_lines in bam_merge_impl.cpp, which removes duplicate alignments produced by different tophat stages. There is logic that attempts to determine if alignments to the same genomic location are actually from different strands and therefore not duplicates, but it relies on the XS tag being set to '+' or '-', which is only true of reads that have been through map2gtf. (Genomic mappings have an XS tag set by bowtie2 to the alignment score of the best secondary mapping, not to strand information). 

A simpler alternative to the logic in BamMerge::next_bam_lines that attempts to determine if consecutive bam lines come from the same location and strand is to just return false in equal_bam() in bam_merge.h if the reverse complement bits in their flags are unequal. After adding this conditional, tophat correctly reports MAPQ=3 alignments to each strand.

![palindrome_fixed](https://cloud.githubusercontent.com/assets/1636913/11637528/d0efb9ee-9cd6-11e5-8ab4-9fb5b85ff73e.png)