### PR TITLE
remove explicit make_pair template arguments

### DIFF
--- a/src/juncs_db.cpp
+++ b/src/juncs_db.cpp
@@ -338,7 +338,7 @@ void driver(const vector<FILE*>& splice_coords_files,
 			uint32_t left_coord = atoi(scan_left_coord);
 			uint32_t right_coord = atoi(scan_right_coord);
 			bool antisense = *orientation == '-';
-			junctions.insert(make_pair<Junction, JunctionStats>(Junction(ref_id, left_coord, right_coord, antisense), JunctionStats()));
+			junctions.insert(make_pair(Junction(ref_id, left_coord, right_coord, antisense), JunctionStats()));
 		}
 	}
 

--- a/src/tophat_reports.cpp
+++ b/src/tophat_reports.cpp
@@ -2705,7 +2705,7 @@ void driver(const string& bam_output_fname,
 				junction_stat.gtf_match = true;
 				junction_stat.accepted = true;
 
-				gtf_junctions.insert(make_pair<Junction, JunctionStats>(Junction(ref_id, left_coord, right_coord, antisense), junction_stat));
+				gtf_junctions.insert(make_pair(Junction(ref_id, left_coord, right_coord, antisense), junction_stat));
 			}
 		}
 		fprintf(stderr, "Loaded %d GFF junctions from %s.\n", (int)(gtf_junctions.size()), gtf_juncs.c_str());


### PR DESCRIPTION
- this causes compilation failures using gcc 6.1.1, e.g.:

```
tophat_reports.cpp:2708:128: error: no matching function for call to ‘make_pair(Junction, JunctionStats&)’
     gtf_junctions.insert(make_pair<Junction, JunctionStats>(Junction(ref_id, left_coord, right_coord, antisense), junction_stat));
                                                                                                                                ^
In file included from /usr/include/c++/6.1.1/bits/stl_algobase.h:64:0,
                 from /usr/include/c++/6.1.1/bits/char_traits.h:39,
                 from /usr/include/c++/6.1.1/string:40,
                 from /usr/include/boost/thread/exceptions.hpp:20,
                 from /usr/include/boost/thread/pthread/thread_data.hpp:10,
                 from /usr/include/boost/thread/thread_only.hpp:17,
                 from /usr/include/boost/thread/thread.hpp:12,
                 from /usr/include/boost/thread.hpp:13,
                 from tophat_reports.cpp:19:
/usr/include/c++/6.1.1/bits/stl_pair.h:425:5: note: candidate: template<class _T1, class _T2> constexpr std::pair<typename std::__decay_and_strip<_Tp>::__type, typename std::__decay_and_strip<_T2>::__type> std::make_pair(_T1&&, _T2&&)
     make_pair(_T1&& __x, _T2&& __y)
     ^~~~~~~~~
/usr/include/c++/6.1.1/bits/stl_pair.h:425:5: note:   template argument deduction/substitution failed:
tophat_reports.cpp:2708:128: note:   cannot convert ‘junction_stat’ (type ‘JunctionStats’) to type ‘JunctionStats&&’
     gtf_junctions.insert(make_pair<Junction, JunctionStats>(Junction(ref_id, left_coord, right_coord, antisense), junction_stat));
                                                                                                                                ^
Makefile:1421: recipe for target 'tophat_reports.o' failed
```

- these failures are possibly related to a newer default c++ standard that is used with the new gcc