### PR TITLE
The existing version fails on symlinks

### DIFF
--- a/src/tophat2.sh
+++ b/src/tophat2.sh
@@ -1,10 +1,11 @@
 #!/usr/bin/env bash
-pbin=""
-fl=$(readlink $0)
-if [[ -z "$fl" ]]; then
-   pbin=$(dirname $0)
- else
-   pbin=$(dirname $fl)
-fi
-export PATH=$pbin:$PATH
-$pbin/tophat "$@"
+# http://stackoverflow.com/a/246128:
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+  DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+  SOURCE="$(readlink "$SOURCE")"
+  [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+done
+DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+export PATH=$DIR:$PATH
+$DIR/tophat "$@"


### PR DESCRIPTION
Great tool, thank you! However, I would like to propose a patch, because we have a small problem with relative symlinks for the current tophat2.sh start script:

readlink returns the plain content of the symlink, which may be a relative path resolved from the directory, the link lives in, for example "../Cellar/tophat/2.1.1_1/bin/tophat2" in case of the brew system (homebrew or linuxbrew). The relative path is handled different by the existing tophat2.sh-script than by a shell resolving a symlink. The shell would resolve it relatively to the link's directory, the original tophat2.sh script tries to resolve it relatively to the current working directory, which usually fails. The proposed change will take care of this issue and set DIR to the real directory tophat2.sh lives in.
For Linux only, the readlink command supports a "-f" parameter making it return the canonical path, but this is non-standard and won't work e.g. on a Mac.

I have tested my patch on Ubuntu 16.04 with linuxbrew and will test it on a current Mac OS X El Capitan, as soon as possible (currently, there seems to be some network problem with homebrew).

I would really be thankful, if you could consider my change, because we heavily use the brew system and would have to patch after each update otherwise. Thank you,

Stephan