### PR TITLE
Do not double open genome fasta in gtf_to_fasta

### DIFF
--- a/src/GTFToFasta.cpp
+++ b/src/GTFToFasta.cpp
@@ -28,7 +28,6 @@ std::string get_exonic_sequence(GffObj &p_trans,
 
 
 GTFToFasta::GTFToFasta(std::string gtf_fname, std::string genome_fname)
-: genome_fhandle_(genome_fname.c_str(), false)
 {
     gtf_fname_ = gtf_fname;
     gtf_fhandle_ = fopen(gtf_fname_.c_str(), "r");

--- a/src/GTFToFasta.h
+++ b/src/GTFToFasta.h
@@ -40,7 +40,10 @@ public:
     void print_mapping();
 private:
     GffReader gtfReader_;
-    GFaSeqGet genome_fhandle_;
+    // The genome_fhandle_ isn't used anywhere after being
+    // initialized, and double opening the fasta file means that pipes
+    // cannot work.
+    // GFaSeqGet genome_fhandle_;
 
     std::string gtf_fname_;
     std::string genome_fname_;


### PR DESCRIPTION
No longer open the genome fasta in the GTFToFasta() and again in
make_transcriptome.

Remove genome_fhandle initializer and member as it is not used
anywhere else.

[This enables the following to work:
`gtf_to_fasta <(gzip -dc Homo_sapiens.GRCh38.84.gtf.gz ) <( gzip -dc Homo_sapiens.GRCh38.dna.toplevel.fa.gz) gtf_fasta.fa` which fails with the current version of gtf_to_fasta.]