### PR TITLE
Clean up tophat's src/Makefile.am

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -792,64 +792,66 @@ libgc_a_SOURCES = \
 	GFaSeqGet.cpp \
 	gff.cpp
 
+lib_LIBRARIES = libtophat.a libgc.a
+
 #-- program sources
 
 prep_reads_SOURCES = prep_reads.cpp
-prep_reads_LDADD = $(top_builddir)/src/libtophat.a $(BAM_LIB)
+prep_reads_LDADD = libtophat.a $(BAM_LIB)
 prep_reads_LDFLAGS = $(BAM_LDFLAGS) $(LDFLAGS) 
 
 segment_juncs_SOURCES = segment_juncs.cpp
-segment_juncs_LDADD = $(top_builddir)/src/libtophat.a $(BOOST_THREAD_LIBS) $(BOOST_SYSTEM_LIB) $(BAM_LIB)
+segment_juncs_LDADD = libtophat.a $(BOOST_THREAD_LIBS) $(BOOST_SYSTEM_LIB) $(BAM_LIB)
 segment_juncs_LDFLAGS = $(BAM_LDFLAGS) $(LDFLAGS) $(BOOST_LDFLAGS)
 
 long_spanning_reads_SOURCES = long_spanning_reads.cpp
-long_spanning_reads_LDADD = $(top_builddir)/src/libtophat.a $(BOOST_THREAD_LIBS) $(BOOST_SYSTEM_LIB) $(BAM_LIB)
+long_spanning_reads_LDADD = libtophat.a $(BOOST_THREAD_LIBS) $(BOOST_SYSTEM_LIB) $(BAM_LIB)
 long_spanning_reads_LDFLAGS = $(BAM_LDFLAGS) $(LDFLAGS) $(BOOST_LDFLAGS)
 
 gtf_juncs_SOURCES = gtf_juncs.cpp
-gtf_juncs_LDADD = $(top_builddir)/src/libtophat.a libgc.a $(BAM_LIB)
+gtf_juncs_LDADD = libtophat.a libgc.a $(BAM_LIB)
 gtf_juncs_LDFLAGS = $(BAM_LDFLAGS) $(LDFLAGS)
 
 juncs_db_SOURCES = juncs_db.cpp
-juncs_db_LDADD = $(top_builddir)/src/libtophat.a $(BAM_LIB)
+juncs_db_LDADD = libtophat.a $(BAM_LIB)
 juncs_db_LDFLAGS = $(BAM_LDFLAGS) $(LDFLAGS)
 
 tophat_reports_SOURCES = tophat_reports.cpp
-tophat_reports_LDADD = $(top_builddir)/src/libtophat.a  $(BOOST_THREAD_LIBS) $(BOOST_SYSTEM_LIB) $(BAM_LIB)
+tophat_reports_LDADD = libtophat.a  $(BOOST_THREAD_LIBS) $(BOOST_SYSTEM_LIB) $(BAM_LIB)
 tophat_reports_LDFLAGS = $(BAM_LDFLAGS) $(LDFLAGS) $(BOOST_LDFLAGS)
 
 fix_map_ordering_SOURCES = fix_map_ordering.cpp
-fix_map_ordering_LDADD = $(top_builddir)/src/libtophat.a $(BAM_LIB)
+fix_map_ordering_LDADD = libtophat.a $(BAM_LIB)
 fix_map_ordering_LDFLAGS = $(BAM_LDFLAGS) $(LDFLAGS)
 
 bam2fastx_SOURCES = bam2fastx.cpp
-bam2fastx_LDADD = $(top_builddir)/src/libgc.a $(BAM_LIB)
+bam2fastx_LDADD = libgc.a $(BAM_LIB)
 bam2fastx_LDFLAGS = $(BAM_LDFLAGS) $(LDFLAGS)
 
 bam_merge_SOURCES = bam_merge.cpp
-bam_merge_LDADD = $(top_builddir)/src/libtophat.a $(top_builddir)/src/libgc.a $(BAM_LIB)
+bam_merge_LDADD = libtophat.a libgc.a $(BAM_LIB)
 bam_merge_LDFLAGS = $(BAM_LDFLAGS) $(LDFLAGS)
 
 sam_juncs_SOURCES = sam_juncs.cpp
-sam_juncs_LDADD = $(top_builddir)/src/libtophat.a $(BAM_LIB)
+sam_juncs_LDADD = libtophat.a $(BAM_LIB)
 sam_juncs_LDFLAGS = $(BAM_LDFLAGS) $(LDFLAGS)
 
 map2gtf_SOURCES = map2gtf.cpp
-map2gtf_LDADD = $(top_builddir)/src/libtophat.a libgc.a $(BAM_LIB)
+map2gtf_LDADD = libtophat.a libgc.a $(BAM_LIB)
 map2gtf_LDFLAGS = $(BAM_LDFLAGS) $(LDFLAGS)
 
 gtf_to_fasta_SOURCES = GTFToFasta.cpp FastaTools.cpp
-gtf_to_fasta_LDADD = $(top_builddir)/src/libtophat.a libgc.a $(BAM_LIB)
+gtf_to_fasta_LDADD = libtophat.a libgc.a $(BAM_LIB)
 gtf_to_fasta_LDFLAGS = $(BAM_LDFLAGS) $(LDFLAGS)
-
 
 libbam_a_SOURCES = 
 samtools_0_1_18_SOURCES = 
 
 $(SAMPROG): $(SAMLIB)
-	
+	true
 
 $(SAMLIB):
+	echo "ZORG!"
 	cd $(SAMDIR) && make $(SAMPROG) && cp $(SAMLIB) $(SAMPROG) ..
 
 install-data-hook:


### PR DESCRIPTION
I'm forwarding this patch from PR #8244 for the Spack package manager,
https://github.com/spack/spack/pull/8244.

Tophat was failing to build with automake@1.16.1, it worked with the
older automake@1.15.1.  This commit adds a patch to Tophat's
`src/Makefile.am` which cleans up a few things.  The result builds
successfully with both automake@1.15.1 and automake@1.16.1.  I have no
way to check that the resulting builds Do The Right Thing.

It changes two things:

- the original Makefile.am had a rule for `$(SAMPROG)` with no
  actions, and since there was a directory there with a tempting name
  the newer automake was trying to do something with it, but lacked
  the appropriate clues.  Since that target is actually made as a side
  effect of making the library (sigh...), it seems to work to just
  give that rule something harmless to do (the Peter Principle
  triumphs again...).

- a bunch of the targets need a `libtophat.a` and `libgc.a`; the older
  automake was probably able to guess what to do given the list of
  sources but the newer automake apparently won't make the necessary
  assumptions.  This patch wires up a simple rule and cleans up the
  appropriate dependencies so that things work.

While it may appear that I'm someone who understands automake, keep in
mind that I only play such a person on a TV reality show.  YMMV.

Closes #53 